### PR TITLE
Fix: Limit angular dependencies to 1.2 and 1.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,10 +19,10 @@
   ],
   "private": false,
   "dependencies": {
-    "angular": "^1.2.17",
-    "angular-route": "^1.2.17"
+    "angular": ">= 1.2 < 1.4",
+    "angular-route": ">= 1.2 < 1.4"
   },
   "devDependencies": {
-    "angular-mocks": "^1.2.17"
+    "angular-mocks": ">= 1.2 < 1.4"
   }
 }


### PR DESCRIPTION
Limit angular dependency to versions 1.2 and 1.3 to fix failing tests
