### PR TITLE
Feature: Option to disable update on route change

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ angular.module("myApp", ["sn.title"])
   ])
 ```
 
+If you do not require the title to be updated on each route change then you can
+disable this functionaility by setting the `update-on-page-change` attribute to `false`:
+
+```html
+<title update-on-page-change="false">My Site Name</title>
+```
+
 This project structure is based on the [angular-seed](https://github.com/angular/angular-seed) application skeleton for a typical [AngularJS](http://angularjs.org/) web app.
 
 The project is preconfigured to install the Angular framework and a bunch of development and testing tools for instant web development gratification.

--- a/app/js/title.js
+++ b/app/js/title.js
@@ -72,6 +72,9 @@ angular.module("sn.title", [])
     function ($rootScope, snTitle, EVENTS, ROUTE_CHANGE_ERROR_TITLE) {
         return {
             restrict: "E",
+            scope: {
+                updateOnPageChange: "="
+            },
             link: function ($scope, $element) {
 
                 /**
@@ -87,9 +90,19 @@ angular.module("sn.title", [])
                     "My Site Name"
                  */
                 var siteTitle =
-                    snTitle.getSiteTitle() && snTitle.getSiteTitle().length > 0 ?
-                        snTitle.getSiteTitle() :
-                        ($element.html().length > 0 ? $element.html() : undefined) ;
+                    (snTitle.getSiteTitle() && snTitle.getSiteTitle().length > 0) ?
+                    snTitle.getSiteTitle() :
+                    ($element.html().length > 0 ? $element.html() : undefined) ;
+
+                /**
+                 * If true will update the page title on every route change.
+                 * This is useful if updating the page title manually to disable
+                 * updates on route change.
+                 * @property updateOnPageChange
+                 * @type     {Boolean}
+                 * @default  true
+                 */
+                var updateOnPageChange = ($scope.updateOnPageChange === false) ? false : true;
 
                 /**
                  * Update the content of the title element to the value
@@ -123,13 +136,16 @@ angular.module("sn.title", [])
                  */
                 var onRouteChangeSuccess = function onRouteChangeSuccess($event, current){
 
-                    var pageTitle = null;
+                    if ( updateOnPageChange ) {
 
-                    if (current && current.$$route && current.$$route.title){
-                        pageTitle = current.$$route.title;
+                        var pageTitle = null;
+
+                        if (current && current.$$route && current.$$route.title){
+                            pageTitle = current.$$route.title;
+                        }
+
+                        setTitle($event, pageTitle);
                     }
-
-                    setTitle($event, pageTitle);
                 };
 
                 /**
@@ -139,11 +155,17 @@ angular.module("sn.title", [])
                  * @method onRouteChangeError
                  */
                 var onRouteChangeError = function onRouteChangeError(){
-                    if (siteTitle){
-                        $element.html(ROUTE_CHANGE_ERROR_TITLE + " - " + siteTitle);
-                    } else {
-                        $element.html(ROUTE_CHANGE_ERROR_TITLE);
+
+                    if ( updateOnPageChange ) {
+
+                        if (siteTitle){
+                            $element.html(ROUTE_CHANGE_ERROR_TITLE + " - " + siteTitle);
+                        } else {
+                            $element.html(ROUTE_CHANGE_ERROR_TITLE);
+                        }
+
                     }
+
                 };
 
                 $rootScope.$on(EVENTS.SET_TITLE, setTitle);

--- a/tests/unit/title.js
+++ b/tests/unit/title.js
@@ -1,7 +1,7 @@
 "use strict";
 
 describe("sn.title:title directive", function() {
-    var element, $scope, $rootScope, errorText;
+    var element, $scope, $rootScope, errorText, snTitle;
 
     beforeEach(module("sn.title"));
 
@@ -77,6 +77,59 @@ describe("sn.title:title directive", function() {
         it("should render directive with error title text", function(){
             $rootScope.$broadcast("$routeChangeError")
             expect(element.html()).toEqual(errorText);
+        });
+
+    });
+
+    describe("Update on page change option disabled", function() {
+
+        beforeEach(inject(function (_$rootScope_, $compile, $injector) {
+            $rootScope = _$rootScope_;
+            spyOn($rootScope, "$broadcast").and.callThrough();
+
+            $scope = $rootScope.$new();
+
+            snTitle = $injector.get("snTitle");
+
+            element = "<title update-on-page-change=\"false\">My Site Name</title>";
+
+            element = $compile(element)($scope);
+            $scope.$digest();
+
+        }));
+
+        it("should render directive with correct title text", function(){
+
+            snTitle.setPageTitle("My custom title");
+            expect($scope.$broadcast).toHaveBeenCalled();
+            expect(element.html()).toEqual("My custom title - My Site Name");
+
+            $rootScope.$broadcast("$routeChangeSuccess", {
+                $$route: {
+                    title: "foo"
+                }
+            })
+            expect(element.html()).toEqual("My custom title - My Site Name");
+
+            $rootScope.$broadcast("$routeChangeSuccess", {
+                $$route: {
+                    title: undefined
+                }
+            })
+            expect(element.html()).toEqual("My custom title - My Site Name");
+        });
+
+         it("should render directive with correct title text on route change error", function(){
+
+            snTitle.setPageTitle("My custom title");
+            expect($scope.$broadcast).toHaveBeenCalled();
+            expect(element.html()).toEqual("My custom title - My Site Name");
+
+            $rootScope.$broadcast("$routeChangeError");
+            expect(element.html()).toEqual("My custom title - My Site Name");
+
+            $rootScope.$broadcast("$routeChangeSuccess");
+            expect(element.html()).toEqual("My custom title - My Site Name");
         });
 
     });


### PR DESCRIPTION
This PR adds the ability to disable the title being updated on every route change by setting the `update-on-page-change` attribute to `false` in the `title` element.

**Example**:

``` html
<title update-on-page-change="false">My Site Name</title>
```

Fixes #3 
