### PR TITLE
Feature: disable e2e tests for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 script:
   - grunt test:development
   - grunt test
-  - grunt e2e --ci
+  # - grunt e2e --ci
 after_success:
   - ./node_modules/coveralls/bin/coveralls.js < coverage/lcov.info
 addons:


### PR DESCRIPTION
e2e tests are causing the build to fail possibly due to a conflict with the protractor webdriver so disabling for now until a solution is found.
