### PR TITLE
Fix: e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp
 .grunt
 *.log
 _SpecRunner.html
+nohup.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ install:
 script:
   - grunt test:development
   - grunt test
-  - ./node_modules/protractor/bin/webdriver-manager update --standalone
-  - grunt e2e --ci --verbose
+  - grunt e2e --ci
 after_success:
   - ./node_modules/coveralls/bin/coveralls.js < coverage/lcov.info
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
 env:
   global:
     - secure: FEQbwSqYZhxfmeh+X2arTWWWv0zCnrkg44EZ0yx+NQSvhKjc4zznHNNwWqViwJTn5fKMQ6ZFNKyFpqtFVgOtVUcEmJHgvFN4afYoMghIKpI6kFQddD4DHH2gsZNySZXjVcjDS1zrRJkcNu9L2N119otGuVv6f28JsdBKrhBVZgY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ env:
     - secure: QIHf5H1Av+RHjXZvT+dljZa/Kv/rsokVYOM9MHBXAa8X30RZcIp/tZuWGGe2SxUhtOMnsOaAn5ladz7KmJ7dsHEHuK2mPh7FMM931nCuGc9mXp15e/z9hj7V3zeT0yCEpOuTS/CHu4002QsEa52FNz01fLZoRvNJAw+d5xftgg4=
 before_install:
   - npm install -g bower grunt-cli protractor
-  - webdriver-manager update && nohup webdriver-manager start &
+  - webdriver-manager update
 install:
   - npm install
 script:
   - grunt test:development
   - grunt test
+  - nohup webdriver-manager start &
   - grunt e2e --ci
 after_success:
   - ./node_modules/coveralls/bin/coveralls.js < coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ env:
     - secure: FEQbwSqYZhxfmeh+X2arTWWWv0zCnrkg44EZ0yx+NQSvhKjc4zznHNNwWqViwJTn5fKMQ6ZFNKyFpqtFVgOtVUcEmJHgvFN4afYoMghIKpI6kFQddD4DHH2gsZNySZXjVcjDS1zrRJkcNu9L2N119otGuVv6f28JsdBKrhBVZgY=
     - secure: QIHf5H1Av+RHjXZvT+dljZa/Kv/rsokVYOM9MHBXAa8X30RZcIp/tZuWGGe2SxUhtOMnsOaAn5ladz7KmJ7dsHEHuK2mPh7FMM931nCuGc9mXp15e/z9hj7V3zeT0yCEpOuTS/CHu4002QsEa52FNz01fLZoRvNJAw+d5xftgg4=
 before_install:
-  - npm install -g bower
-  - npm install -g grunt-cli
-  - npm install -g protractor
+  - npm install -g bower grunt-cli protractor
 install:
   - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ install:
 script:
   - grunt test:development
   - grunt test
-  - grunt e2e --ci
+  - ./node_modules/protractor/bin/webdriver-manager update --standalone
+  - grunt e2e --ci --verbose
 after_success:
   - ./node_modules/coveralls/bin/coveralls.js < coverage/lcov.info
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 script:
   - grunt test:development
   - grunt test
-  # - grunt e2e --ci
+  - grunt e2e --ci
 after_success:
   - ./node_modules/coveralls/bin/coveralls.js < coverage/lcov.info
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - secure: QIHf5H1Av+RHjXZvT+dljZa/Kv/rsokVYOM9MHBXAa8X30RZcIp/tZuWGGe2SxUhtOMnsOaAn5ladz7KmJ7dsHEHuK2mPh7FMM931nCuGc9mXp15e/z9hj7V3zeT0yCEpOuTS/CHu4002QsEa52FNz01fLZoRvNJAw+d5xftgg4=
 before_install:
   - npm install -g bower grunt-cli protractor
+  - webdriver-manager update && nohup webdriver-manager start &
 install:
   - npm install
 script:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -362,7 +362,7 @@ module.exports = function (grunt) {
         "copy",
         "processhtml:e2e",
         "connect:servertest",
-        "protractor_webdriver",
+        // "protractor_webdriver",
         "protractor:dist",
         "clean:afterTest"
     ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -168,7 +168,7 @@ module.exports = function (grunt) {
         protractor_webdriver: {
             dist: {
                 options: {
-                    path: "./node_modules/grunt-protractor-runner/node_modules/protractor/bin/",
+                    path: "./node_modules/protractor/bin/",
                     command: "webdriver-manager update && webdriver-manager start"
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -168,8 +168,8 @@ module.exports = function (grunt) {
         protractor_webdriver: {
             dist: {
                 options: {
-                    path: "./node_modules/protractor/bin/",
-                    command: "webdriver-manager update && webdriver-manager start"
+                    command: "./node_modules/protractor/bin/webdriver-manager update &&" +
+                             "./node_modules/protractor/bin/webdriver-manager start"
                 }
             }
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,7 +169,7 @@ module.exports = function (grunt) {
             dist: {
                 options: {
                     path: "./node_modules/grunt-protractor-runner/node_modules/protractor/bin/",
-                    command: "webdriver-manager update && webdriver-manager start",
+                    command: "webdriver-manager update && webdriver-manager start"
                 }
             }
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,15 +165,6 @@ module.exports = function (grunt) {
             }
         },
 
-        protractor_webdriver: {
-            dist: {
-                options: {
-                    command: "./node_modules/protractor/bin/webdriver-manager update &&" +
-                             "./node_modules/protractor/bin/webdriver-manager start"
-                }
-            }
-        },
-
         concat: {
             options: {
                 sourceMap: false,
@@ -304,7 +295,6 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-contrib-yuidoc");
     grunt.loadNpmTasks("grunt-contrib-jasmine");
     grunt.loadNpmTasks("grunt-protractor-runner");
-    grunt.loadNpmTasks("grunt-protractor-webdriver");
     grunt.loadNpmTasks("grunt-processhtml");
     grunt.loadNpmTasks('grunt-bump');
 
@@ -362,7 +352,6 @@ module.exports = function (grunt) {
         "copy",
         "processhtml:e2e",
         "connect:servertest",
-        // "protractor_webdriver",
         "protractor:dist",
         "clean:afterTest"
     ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -168,6 +168,7 @@ module.exports = function (grunt) {
         protractor_webdriver: {
             dist: {
                 options: {
+                    path: "./node_modules/protractor/bin/",
                     command: "webdriver-manager update && webdriver-manager start",
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -168,7 +168,7 @@ module.exports = function (grunt) {
         protractor_webdriver: {
             dist: {
                 options: {
-                    path: "./node_modules/protractor/bin/",
+                    path: "./node_modules/grunt-protractor-runner/node_modules/protractor/bin/",
                     command: "webdriver-manager update && webdriver-manager start",
                 }
             }

--- a/README.md
+++ b/README.md
@@ -273,13 +273,14 @@ correctly. Therefore, our web server needs to be serving up the application, so 
 can interact with it. To run end to end tests we first need to install protractor with global permissions. You may need to run this command with superuser privileges:
 
 ```
-npm install -g protractor
+npm install -g protractor && webdriver-manager update
 ```
 
 Once you have ensured that the development web server hosting our application is up and running
 and WebDriver is updated, you can run the end-to-end tests using the supplied grunt task:
 
 ```
+nohup webdriver-manager start &
 grunt e2e
 ```
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "grunt-contrib-yuidoc": "~0.5.2",
     "grunt-processhtml": "~0.3.3",
     "grunt-protractor-runner": "~2.1.0",
-    "grunt-protractor-webdriver": "git://github.com/seckardt/grunt-protractor-webdriver.git#e4bea15",
     "grunt-template-jasmine-istanbul": "~0.3.1",
     "protractor": "~2.4.0",
     "yuidoc-bootstrap-theme": "~1.0.4"

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-yuidoc": "~0.5.2",
     "grunt-processhtml": "~0.3.3",
-    "grunt-protractor-runner": "~1.1.4",
+    "grunt-protractor-runner": "~2.1.0",
     "grunt-protractor-webdriver": "git://github.com/seckardt/grunt-protractor-webdriver#e4bea15",
     "grunt-template-jasmine-istanbul": "~0.3.1",
-    "protractor": "~1.4.0",
+    "protractor": "~2.4.0",
     "yuidoc-bootstrap-theme": "~1.0.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-contrib-yuidoc": "~0.5.2",
     "grunt-processhtml": "~0.3.3",
     "grunt-protractor-runner": "~1.1.4",
-    "grunt-protractor-webdriver": "~0.1.9",
+    "grunt-protractor-webdriver": "git://github.com/seckardt/grunt-protractor-webdriver#e4bea15",
     "grunt-template-jasmine-istanbul": "~0.3.1",
     "protractor": "~1.4.0",
     "yuidoc-bootstrap-theme": "~1.0.4"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-contrib-yuidoc": "~0.5.2",
     "grunt-processhtml": "~0.3.3",
     "grunt-protractor-runner": "~2.1.0",
-    "grunt-protractor-webdriver": "git://github.com/seckardt/grunt-protractor-webdriver#e4bea15",
+    "grunt-protractor-webdriver": "git://github.com/seckardt/grunt-protractor-webdriver.git#e4bea15",
     "grunt-template-jasmine-istanbul": "~0.3.1",
     "protractor": "~2.4.0",
     "yuidoc-bootstrap-theme": "~1.0.4"

--- a/tests/e2e/protractor.conf.js
+++ b/tests/e2e/protractor.conf.js
@@ -53,7 +53,7 @@ exports.config = {
   //
   // Spec patterns are relative to the location of this config.
   specs: [
-    'specs/*.js',
+    'specs/*.js'
   ],
 
   // ----- Capabilities to be passed to the webdriver instance ----

--- a/tests/e2e/protractor.saucelabs.conf.js
+++ b/tests/e2e/protractor.saucelabs.conf.js
@@ -19,29 +19,31 @@ exports.config = {
     'specs/*.js'
   ],
 
+  // Saucelabs capabilities reference
+  // https://docs.saucelabs.com/reference/platforms-configurator/#/
   multiCapabilities: [{
     'browserName': 'chrome',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name':  pkg.name + ' (Chrome: Linux) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
-    'version': '39',
-    'selenium-version': '2.43.1',
+    'version': '45',
+    'selenium-version': '2.47.1',
     'platform': 'Linux'
   }, {
     'browserName': 'firefox',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name':  pkg.name + ' (FF: Linux) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
-    'version': '34',
-    'selenium-version': '2.43.1',
+    'version': '41',
+    'selenium-version': '2.47.1',
     'platform': 'Linux'
   }, {
     'browserName': 'safari',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
-    'name':  pkg.name + ' (Safari: OS X 10.10) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
-    'version': '8',
-    'selenium-version': '2.43.1',
+    'name':  pkg.name + ' (Safari: OS X 10.11) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
+    'version': '8.0',
+    'selenium-version': '2.47.1',
     'platform': 'OS X 10.10'
   }, {
     'browserName': 'internet explorer',
@@ -49,7 +51,7 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name':  pkg.name + ' (IE11: Win 8.1) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
     'version': '11',
-    'selenium-version': '2.43.1',
+    'selenium-version': '2.47.1',
     'platform': 'Windows 8.1'
   }, {
     'browserName': 'internet explorer',
@@ -57,30 +59,26 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name':  pkg.name + ' (IE10: Win 8) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
     'version': '10',
-    'selenium-version': '2.43.1',
+    'selenium-version': '2.47.1',
     'platform': 'Windows 8'
   }, {
-    'browserName': 'chrome',
+    'browserName': 'android',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
-    'name':  pkg.name + ' (Chrome: Android 5.0) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
-    'version': '5.0',
-    'platformVersion': '5.0',
-    'platformName': 'Android',
-    'appiumVersion': '1.3.4',
+    'name':  pkg.name + ' (Andriod Browser: Android 5.1) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
+    'version': '5.1',
     'deviceName': 'Android Emulator',
+    'selenium-version': '2.47.1',
     'device-orientation': 'portrait'
   }, {
-    'browserName': 'safari',
+    'browserName': 'iphone',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
-    'name':  pkg.name + ' (Safari: iOS 8.1) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
-    'version': '8.1',
-    'platformVersion': '8.1',
-    'platformName': 'iOS',
-    'appiumVersion': '1.3.4',
-    'platform': 'iOS',
-    'deviceName': 'iPhone Simulator',
+    'name':  pkg.name + ' (Safari: iOS 9.0) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
+    'platform': 'OS X 10.10',
+    'version': '9',
+    'deviceName': 'iPhone 6',
+    'selenium-version': '2.47.1',
     'device-orientation': 'portrait'
   }],
 

--- a/tests/e2e/protractor.saucelabs.conf.js
+++ b/tests/e2e/protractor.saucelabs.conf.js
@@ -27,59 +27,55 @@ exports.config = {
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name':  pkg.name + ' (Chrome: Linux) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
     'version': '45',
-    'selenium-version': '2.47.1',
     'platform': 'Linux'
-  }, {
+  },{
     'browserName': 'firefox',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name':  pkg.name + ' (FF: Linux) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
     'version': '41',
-    'selenium-version': '2.47.1',
     'platform': 'Linux'
-  }, {
+  },{
     'browserName': 'safari',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name':  pkg.name + ' (Safari: OS X 10.11) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
-    'version': '8.0',
-    'selenium-version': '2.47.1',
-    'platform': 'OS X 10.10'
-  }, {
+    'version': '8.1',
+    'platform': 'OS X 10.11'
+  },{
     'browserName': 'internet explorer',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name':  pkg.name + ' (IE11: Win 8.1) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
     'version': '11',
-    'selenium-version': '2.47.1',
     'platform': 'Windows 8.1'
-  }, {
+  },{
     'browserName': 'internet explorer',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
     'name':  pkg.name + ' (IE10: Win 8) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
     'version': '10',
-    'selenium-version': '2.47.1',
     'platform': 'Windows 8'
-  }, {
-    'browserName': 'android',
+  },{
+    'browserName': 'Browser',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
-    'name':  pkg.name + ' (Andriod Browser: Android 5.1) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
-    'version': '5.1',
+    'name':  pkg.name + ' (Android Browser: Android 5.1) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
+    'platformName': 'Android',
+    'platformVersion': '5.1',
     'deviceName': 'Android Emulator',
-    'selenium-version': '2.47.1',
-    'device-orientation': 'portrait'
-  }, {
-    'browserName': 'iphone',
+    'appiumVersion': '1.4.11',
+    'deviceOrientation': 'portrait'
+  },{
+    'browserName': 'Safari',
     'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
     'build': process.env.TRAVIS_BUILD_NUMBER,
-    'name':  pkg.name + ' (Safari: iOS 9.0) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
-    'platform': 'OS X 10.10',
-    'version': '9',
+    'name':  pkg.name + ' (Safari: iOS 8.2) Build: ' + process.env.TRAVIS_BUILD_NUMBER,
+    'platformVersion': '8.2',
+    'platformName': 'iOS',
     'deviceName': 'iPhone 6',
-    'selenium-version': '2.47.1',
-    'device-orientation': 'portrait'
+    'appiumVersion': '1.3.7',
+    'deviceOrientation': 'portrait'
   }],
 
   // ----- More information for your tests ----
@@ -93,11 +89,11 @@ exports.config = {
   rootElement: 'body',
 
   onPrepare: function() {
-    browser.getCapabilities().then(function (cap) {
-      if ((cap.caps_.platform !== "iOS") && (cap.caps_.platform !== "ANDROID")){
-        browser.driver.manage().window().setSize(1366, 768)
-      }
-    });
+    // browser.getCapabilities().then(function (cap) {
+    //   if ((cap.caps_.platform !== "iOS") && (cap.caps_.platform !== "ANDROID")){
+    //     browser.driver.manage().window().setSize(1366, 768)
+    //   }
+    // });
   },
 
   // ----- The test framework -----

--- a/tests/e2e/protractor.saucelabs.conf.js
+++ b/tests/e2e/protractor.saucelabs.conf.js
@@ -16,7 +16,7 @@ exports.config = {
   //
   // Spec patterns are relative to the location of this config.
   specs: [
-    'specs/*.js',
+    'specs/*.js'
   ],
 
   multiCapabilities: [{


### PR DESCRIPTION
This PR restores the e2e tests. The issue was being caused by the `grunt-protractor-webdriver` module being broken by the latest version of the selenium webdriver changing it's output. I've removed and module and started the webdriver manually in `.travis.yml` 
